### PR TITLE
Feature/iam instance profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # dq-packer-peering-haproxy
-This repository creates an AMI in AWS with HAProxy with logging to rsyslog
+This repository creates an AMI in AWS with [HAProxy](http://www.haproxy.org/download/1.7/doc/intro.txt) with logging to [rsyslog](https://www.rsyslog.com/)
+
 
 ## `packer.json`
-This file contains a wrap up for Ansible script to be run inside small RedHat 7.5 machine
+This file contains a wrap up for Ansible script to be run inside small Red Hat Enterprise Linux 8.x machine
 
 ## `playbook.yml`
 Ansible playbook installing the following:
 - rsyslog
-- HAProxy v.1.7.11 - installed from source and compiled locally wih the follwing options:
+- HAProxy v.1.7.14 - installed from source and compiled locally wih the following options:
     - TARGET: linux2628
     - USE_PCRE: 1
     - USE_OPENSSL: 1

--- a/packer.json
+++ b/packer.json
@@ -12,6 +12,7 @@
       "access_key": "{{user `access_key`}}",
       "secret_key": "{{user `secret_key`}}",
       "region": "{{user `region`}}",
+      "iam_instance_profile": "packer_builder",
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",

--- a/packer.json
+++ b/packer.json
@@ -3,7 +3,8 @@
     "access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
     "secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
     "region":  "{{env `AWS_DEFAULT_REGION`}}",
-    "drone_build_number": "{{env `DRONE_BUILD_NUMBER`}}"
+    "drone_build_number": "{{env `DRONE_BUILD_NUMBER`}}",
+    "drone_repo_name": "{{env `DRONE_REPO_NAME`}}"
   },
   "sensitive-variables": ["access_key", "secret_key"],
   "builders": [
@@ -23,6 +24,9 @@
           "309956199498"
         ],
         "most_recent": true
+      },
+      "run_tags":{
+            "Name": "Packer Build [{{user `drone_repo_name`}}: {{user `drone_build_number`}}]"
       },
       "launch_block_device_mappings": [
         {
@@ -46,7 +50,7 @@
       "type": "ansible",
       "playbook_file": "./playbook.yml",
       "extra_arguments": [
-        "--extra-vars", "ansible_shell_type=sh AWS_ACCESS_KEY_ID={{user `access_key`}} AWS_SECRET_ACCESS_KEY={{user `secret_key`}}",
+        "--extra-vars", "ansible_shell_type=sh",
         "--ssh-extra-args", "-o IdentitiesOnly=yes -o 'HostKeyAlgorithms=+ssh-rsa' -o 'PubkeyAcceptedAlgorithms=+ssh-rsa'",
         "--scp-extra-args", "'-O'"
       ]

--- a/playbook.yml
+++ b/playbook.yml
@@ -44,11 +44,11 @@
         enabled: yes
         state: restarted
 
-    - name: Get haproxy
+    - name: Get haproxy - 1.7.14 (2021-03-31) # Look out for updates - they seem to happen ~once per year
       unarchive:
-        src: http://www.haproxy.org/download/1.7/src/haproxy-1.7.9.tar.gz
+        src: http://www.haproxy.org/download/1.7/src/haproxy-1.7.14.tar.gz
         dest: /usr/src/
-        creates: /usr/src/haproxy-1.7.9
+        creates: /usr/src/haproxy-1.7.14
         remote_src: yes
 
     - name: DNF Install Dependencies
@@ -72,7 +72,7 @@
 
     - name: Make haproxy
       make:
-        chdir: /usr/src/haproxy-1.7.9
+        chdir: /usr/src/haproxy-1.7.14
         params:
           TARGET: linux2628
           USE_PCRE: 1
@@ -82,13 +82,13 @@
 
     - name: Install haproxy
       make:
-        chdir: /usr/src/haproxy-1.7.9
+        chdir: /usr/src/haproxy-1.7.14
         target: install
 
     - name: Copy haproxy.init
       copy:
         remote_src: yes
-        src: /usr/src/haproxy-1.7.9/examples/haproxy.init
+        src: /usr/src/haproxy-1.7.14/examples/haproxy.init
         dest: /etc/init.d/haproxy
         mode: 0755
 
@@ -155,9 +155,6 @@
 
     - name: GET CloudWatch logs config from DQ-config-bucket - cp
       command: /usr/local/bin/aws s3 cp s3://dq-config-bucket/dq-tableau-linux/awslogs-agent-setup.py /tmp
-      environment: # Shouldn't be necessary to add env vars - but it is
-        AWS_ACCESS_KEY_ID: "{{ lookup('ansible.builtin.env', 'AWS_ACCESS_KEY_ID') }}"
-        AWS_SECRET_ACCESS_KEY: "{{ lookup('ansible.builtin.env', 'AWS_SECRET_ACCESS_KEY') }}"
 
     - name: Set CloudWatch logs config executable
       command: chmod u+x /tmp/awslogs-agent-setup.py


### PR DESCRIPTION
*What changes does this PR bring?*

Removes explicit passing of AWS Keys (rendered unnecessary by the use of an IAM Instance Profile).
Upgrades HAProxy (from 2017 version (1.7.9) to latest (1.7.14)).
Added Packer run-tags - to name the Packer Builder EC2 Instance.